### PR TITLE
Adds default BERT Model

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -95,6 +95,9 @@ let package = Package(
         .target(
             name: "Bert",
             dependencies: [ "llama" ],
+            resources: [
+                .process("Resources")
+            ],
             publicHeadersPath: "include",
             cSettings: [
                 .define("GGML_USE_ACCELERATE"),

--- a/tests/BertTests/BertTests.mm
+++ b/tests/BertTests/BertTests.mm
@@ -26,7 +26,7 @@
     NSBundle *bundle = SWIFTPM_MODULE_BUNDLE;
     NSURL *resourceURL = [bundle URLForResource:@"ggml-model-f32" withExtension:@"bin"];
     NSURL *earningsResourceURL = [bundle URLForResource:@"earnings" withExtension:@"txt"];
-    BertEncoder * encoder = [[BertEncoder alloc] initWithModelURL:resourceURL];
+    BertEncoder * encoder = [[BertEncoder alloc] init];
     [encoder start];
     NSArray<NSString *> * result = [encoder findClosestTextForSentence:@"Who is the CEO?" inResourceURL:earningsResourceURL topN:3];
     NSLog(@"%@", result);


### PR DESCRIPTION
Adds the BERT sentence embeddings model by default so consuming apps (EchoVaultMac) don't have to specify the model path.

This PR also ensures interaction with the BertEncoder is thread safe.